### PR TITLE
Avoid warnings of not portable preprocessor

### DIFF
--- a/poly1305-donna.c
+++ b/poly1305-donna.c
@@ -11,11 +11,13 @@
 #else
 
 /* auto detect between 32bit / 64bit */
-#define HAS_SIZEOF_INT128_64BIT (defined(__SIZEOF_INT128__) && defined(__LP64__))
-#define HAS_MSVC_64BIT (defined(_MSC_VER) && defined(_M_X64))
-#define HAS_GCC_4_4_64BIT (defined(__GNUC__) && defined(__LP64__) && ((__GNUC__ > 4) || ((__GNUC__ == 4) && (__GNUC_MINOR__ >= 4))))
-
-#if (HAS_SIZEOF_INT128_64BIT || HAS_MSVC_64BIT || HAS_GCC_4_4_64BIT)
+#if /* uint128 available on 64bit system*/ \
+	(defined(__SIZEOF_INT128__) && defined(__LP64__)) \
+	/* MSVC 64bit compiler */ \
+	|| (defined(_MSC_VER) && defined(_M_X64)) \
+	/* gcc >= 4.4 64bit compiler */ \
+	|| (defined(__GNUC__) && defined(__LP64__) && \
+		((__GNUC__ > 4) || ((__GNUC__ == 4) && (__GNUC_MINOR__ >= 4)))) 
 #include "poly1305-donna-64.h"
 #else
 #include "poly1305-donna-32.h"


### PR DESCRIPTION
clang & gcc were giving a warning (either with `-Wpedantic` or `-Werror`) about using defined as an expansion, it was fine as it was only expanded inside preprocessor, but here is an alternative for the same logic.

warning message:
> poly1305-donna.c:18:6: warning: this use of "defined" may not be portable [-Wexpansion-to-defined]