### PR TITLE
Avoid the direct use of 'defined' in macro expansion

### DIFF
--- a/poly1305-donna.c
+++ b/poly1305-donna.c
@@ -11,9 +11,23 @@
 #else
 
 /* auto detect between 32bit / 64bit */
-#define HAS_SIZEOF_INT128_64BIT (defined(__SIZEOF_INT128__) && defined(__LP64__))
-#define HAS_MSVC_64BIT (defined(_MSC_VER) && defined(_M_X64))
-#define HAS_GCC_4_4_64BIT (defined(__GNUC__) && defined(__LP64__) && ((__GNUC__ > 4) || ((__GNUC__ == 4) && (__GNUC_MINOR__ >= 4))))
+#if defined(__SIZEOF_INT128__) && defined(__LP64__)
+#define HAS_SIZEOF_INT128_64BIT 1
+#else
+#define HAS_SIZEOF_INT128_64BIT 0
+#endif
+
+#if defined(_MSC_VER) && defined(_M_X64)
+#define HAS_MSVC_64BIT 1
+#else
+#define HAS_MSVC_64BIT 0
+#endif
+
+#if defined(__GNUC__) && defined(__LP64__) && ((__GNUC__ > 4) || ((__GNUC__ == 4) && (__GNUC_MINOR__ >= 4)))
+#define HAS_GCC_4_4_64BIT 1
+#else
+#define HAS_GCC_4_4_64BIT 0
+#endif
 
 #if (HAS_SIZEOF_INT128_64BIT || HAS_MSVC_64BIT || HAS_GCC_4_4_64BIT)
 #include "poly1305-donna-64.h"


### PR DESCRIPTION
If a defined operator appears as the result of a macro expansion, the
C standard specifies the behavior as undefined.

Fixes "-Wexpansion-to-defined" warnings produced by clang >=3.9:

```
poly1305-donna.c:18:6: warning: macro expansion producing 'defined' has undefined behavior [-Wexpansion-to-defined]
#if (HAS_SIZEOF_INT128_64BIT || HAS_MSVC_64BIT || HAS_GCC_4_4_64BIT)
     ^
poly1305-donna.c:14:34: note: expanded from macro 'HAS_SIZEOF_INT128_64BIT'
#define HAS_SIZEOF_INT128_64BIT (defined(__SIZEOF_INT128__) && defined(__LP64__))
                                 ^
poly1305-donna.c:18:6: warning: macro expansion producing 'defined' has undefined behavior [-Wexpansion-to-defined]
poly1305-donna.c:14:64: note: expanded from macro 'HAS_SIZEOF_INT128_64BIT'
#define HAS_SIZEOF_INT128_64BIT (defined(__SIZEOF_INT128__) && defined(__LP64__))
                                                               ^
poly1305-donna.c:18:33: warning: macro expansion producing 'defined' has undefined behavior [-Wexpansion-to-defined]
#if (HAS_SIZEOF_INT128_64BIT || HAS_MSVC_64BIT || HAS_GCC_4_4_64BIT)
                                ^
poly1305-donna.c:15:25: note: expanded from macro 'HAS_MSVC_64BIT'
#define HAS_MSVC_64BIT (defined(_MSC_VER) && defined(_M_X64))
                        ^
poly1305-donna.c:18:33: warning: macro expansion producing 'defined' has undefined behavior [-Wexpansion-to-defined]
poly1305-donna.c:15:46: note: expanded from macro 'HAS_MSVC_64BIT'
#define HAS_MSVC_64BIT (defined(_MSC_VER) && defined(_M_X64))
                                             ^
poly1305-donna.c:18:51: warning: macro expansion producing 'defined' has undefined behavior [-Wexpansion-to-defined]
#if (HAS_SIZEOF_INT128_64BIT || HAS_MSVC_64BIT || HAS_GCC_4_4_64BIT)
                                                  ^
poly1305-donna.c:16:28: note: expanded from macro 'HAS_GCC_4_4_64BIT'
#define HAS_GCC_4_4_64BIT (defined(__GNUC__) && defined(__LP64__) && ((__GNUC__ > 4) || ((__GNUC__ == 4) && (__GNUC_MINOR__ >= 4))))
                           ^
poly1305-donna.c:18:51: warning: macro expansion producing 'defined' has undefined behavior [-Wexpansion-to-defined]
poly1305-donna.c:16:49: note: expanded from macro 'HAS_GCC_4_4_64BIT'
#define HAS_GCC_4_4_64BIT (defined(__GNUC__) && defined(__LP64__) && ((__GNUC__ > 4) || ((__GNUC__ == 4) && (__GNUC_MINOR__ >= 4))))
```

Issue  appeared  in `john the ripper`:

- [https://github.com/openwall/john/issues/4537](https://github.com/openwall/john/issues/4537)
- [Avoid the direct use of 'defined' in macro expansion ](https://github.com/openwall/john/pull/4539#issuecomment-755277913)